### PR TITLE
Update add_alias_info.clj

### DIFF
--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -46,6 +46,7 @@
   If this clause is 'selected', this is the position the clause will appear in the results (i.e. the corresponding
   column index)."
   (:require
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.driver :as driver]
@@ -352,7 +353,7 @@
   (cond
     join-alias              (prefix-field-alias join-alias (or alias-from-join field-name))
     alias-from-source-query alias-from-source-query
-    :else                   field-name))
+    :else                   (str/replace field-name #"_id." "")))
 
 (defmulti ^:private clause-alias-info
   {:arglists '([inner-query unique-alias-fn clause])}


### PR DESCRIPTION

### Description

the desired_alias field would have an extra "_id" prefix in the group and project stages if it was nested under "_id"

### How to verify

Describe the steps to verify that the changes are working as expected.

1. create any collection and insert this document ` {"_id": {"nestedChildField": "anotherNestedChildField"}}}`
2. go to admin -> databases -> select database -> sync 
3. go to admin -> troubleshooting -> view logs
4. an error is thrown at the logs attempting to fingerprint-table


```
2023-11-10 21:34:47,834 WARN sync.util :: Error fingerprinting Table 198 'collection'
com.mongodb.MongoCommandException: Command failed with error 31249 (Location31249): 'Invalid $project :: caused by :: Path collision at _id.nestedChildField remaining portion nestedChildField.anotherNestedChildField on server localhost:27017.
```

### Demo

using a nested _id field now displays the correct query

[Screencast from 11-10-2023 10:18:08 PM.webm](https://github.com/Kidoz-SDK/metabase/assets/77276477/6ffe3200-1e4c-4d94-9b1b-8ec33445e265)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
